### PR TITLE
Update gems in example app

### DIFF
--- a/materials/canonical/session19/WebApp/Gemfile.lock
+++ b/materials/canonical/session19/WebApp/Gemfile.lock
@@ -1,13 +1,14 @@
 GEM
+  remote: https://rubygems.org/
   specs:
-    rack (1.6.4)
-    rack-protection (1.5.3)
+    rack (1.6.11)
+    rack-protection (1.5.5)
       rack
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
-    tilt (2.0.1)
+    tilt (2.0.9)
 
 PLATFORMS
   ruby
@@ -16,4 +17,4 @@ DEPENDENCIES
   sinatra (= 1.4.6)
 
 BUNDLED WITH
-   1.10.6
+   1.17.2


### PR DESCRIPTION
This gets rid of the Github security warnings.

![Screenshot 2019-08-26 at 18 27 14](https://user-images.githubusercontent.com/677998/63706215-228a0700-c82f-11e9-9c15-8372e79130df.png)
