### PR TITLE
fix topics of ranges and symbols exercises

### DIFF
--- a/exercises/10/ranges.md
+++ b/exercises/10/ranges.md
@@ -1,9 +1,7 @@
 ---
 layout: exercises
-topic: Symbols and Ranges
+topic: Ranges
 ---
-
-### Ranges
 
 1. Create a new file in your directory
 

--- a/exercises/10/symbols.md
+++ b/exercises/10/symbols.md
@@ -1,9 +1,7 @@
 ---
 layout: exercises
-topic: Symbols and Ranges
+topic: Symbols
 ---
-
-### Symbols
 
 We are going to make a dictionary for whatever two languages you know. The key is always a word or expression in the source language, whereas the value is a word or expression in the target language.
 


### PR DESCRIPTION
Recently, we split the exercise "Symbols and Ranges" into two separate exercises. We forgot to adjust the title ("topic"), it still said

![Screenshot 2020-05-04 at 20 18 17](https://user-images.githubusercontent.com/1409672/80999149-7d571200-8e44-11ea-913d-d7e5e01ece78.png)
